### PR TITLE
Fix typos in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
     entrypoint: ['sleep', '60000']
     #entrypoint: ["python3", "manage.py", "daemon", "start-foreground"]
     networks:
-      shared_politk-bei-uns:
+      shared_politik-bei-uns:
         aliases:
           - daemon
 
 networks:
-  shared_politk-bei-uns:
+  shared_politik-bei-uns:
     external: true


### PR DESCRIPTION
`shared_politk-bei-uns` -> `shared_politik-bei-uns`.

I've ensured that these are the only two places in the repository where `shared_politk-bei-uns` appeared previously.