### PR TITLE
Add basic Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+- "3.5"
+install:
+# For local unit and integration tests
+- pip install -r requirements.txt
+# To test the Docker container itself
+- docker-compose build
+script:
+- bash -c "echo 'Run tests here'"


### PR DESCRIPTION
Addresses #4.

This is just a proposal - I have used Travis CI before so I used that, but plenty of alternatives exist.

Currently this sets up the following:
- A local test environment with Python 3.5 and all the packages from `requirements.txt` installed
- The Docker image defined in `docker-compose.yml` and `Dockerfile`

Since I could not find any unit tests at a quick glance, this does not currently run any tests.

I believe this adds some value anyway since it checks at least that the Python package dependencies can be downloaded and that the Docker image can be built and composed.

To see the Travis CI build status on GitHub PRs, this GitHub App needs to be set up: https://github.com/marketplace/travis-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW43MA==#pricing-and-setup

I've set up a Travis CI integration for my fork - see here for what the output looks like: https://travis-ci.com/curiousleo/daemon